### PR TITLE
Remove manual file closing and add exit() on exception

### DIFF
--- a/crystalatte/crystalatte.py
+++ b/crystalatte/crystalatte.py
@@ -866,8 +866,7 @@ def cif_main(fNameIn, fNameOut, Na, Nb, Nc, monomer_cutoff, nmer_cutoff, make_re
 
     except:
         print('\nERROR: Failed to write to XYZ output file')
-
-    fOut.close()
+        sys.exit()
 
     return(monomer_cutoff)
 


### PR DESCRIPTION
## Description
Remove manual file closing and add exit() on exception. This prevents an unrelated exception happening when there is an error writing to an XYZ file or something

## Status
- [X] Ready to go